### PR TITLE
Updating to adapt to interface dll changes. Updating flatbuffer header.

### DIFF
--- a/inc/rlbot/interface.h
+++ b/inc/rlbot/interface.h
@@ -49,5 +49,7 @@ public:
                            int botIndex, bool teamOnly);
   static int SetGameState(GameState state);
   static int StartMatch(MatchSettings settings);
+  static int StartTcpCommunication(int port, bool wantsBallPredictions, bool wantsQuickChat, bool wantsGameMessages);
+  static bool IsReadyForCommunication();
 };
 } // namespace rlbot

--- a/src/botmanager.cc
+++ b/src/botmanager.cc
@@ -1,4 +1,6 @@
 #include "rlbot/botmanager.h"
+#include <chrono>
+#include <thread>
 
 namespace rlbot {
 BotManager::BotManager(Bot *(*botfactory)(int, int, std::string)) {
@@ -15,10 +17,16 @@ void BotManager::StartBotServer(uint16_t port) {
 }
 
 void BotManager::RecieveMessage(Message message) {
+  using namespace std::chrono_literals;
   if (message.command == Command::Add) {
     if (!Interface::IsInterfaceLoaded()) {
       Interface::LoadInterface(message.dll_dir + platform::fileSeperator +
                                DLLNAME);
+      Interface::StartTcpCommunication(23234, true, true, true);
+      std::cout << "CPP bot manager waiting for the interface to connect..." << std::endl;
+      while (!Interface::IsReadyForCommunication()) {
+        std::this_thread::sleep_for(50ms);
+      }
     }
     AddBot(message.index, message.team, message.name);
   } else if (message.command == Command::Remove) {

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -11,6 +11,7 @@ typedef ByteBuffer (*ByteBufferFunc)(void);
 typedef void (*VoidFunc)(void *);
 typedef int (*SendPacketFunc)(void *, int);
 typedef ByteBuffer (*ReceiveQuickChatFunc)(int, int, int);
+typedef int (*CommsFunc)(int, bool, bool, bool);
 
 BoolFunc _isInitialized;
 VoidFunc _free;
@@ -26,6 +27,8 @@ SendPacketFunc _renderGroup;
 SendPacketFunc _sendQuickChat;
 SendPacketFunc _setGameState;
 SendPacketFunc _startMatchFlatbuffer;
+CommsFunc _startTcpCommunication;
+BoolFunc _isReadyForCommunication;
 
 bool Interface::isLoaded = false;
 
@@ -58,6 +61,10 @@ void Interface::LoadInterface(std::string dll) {
       (SendPacketFunc)platform::GetFunctionAddress(handle, "SetGameState");
   _startMatchFlatbuffer = (SendPacketFunc)platform::GetFunctionAddress(
       handle, "StartMatchFlatbuffer");
+  _startTcpCommunication = (CommsFunc)platform::GetFunctionAddress(
+          handle, "StartTcpCommunication");
+  _isReadyForCommunication = (BoolFunc)platform::GetFunctionAddress(
+          handle, "IsReadyForCommunication");
 
   isLoaded = true;
 }
@@ -128,5 +135,13 @@ int Interface::StartMatch(MatchSettings settings) {
   builder.Finish(settings.BuildFlatBuffer(builder));
 
   return _startMatchFlatbuffer(builder.GetBufferPointer(), builder.GetSize());
+}
+
+int Interface::StartTcpCommunication(int port, bool wantsBallPredictions, bool wantsQuickChat, bool wantsGameMessages) {
+    return _startTcpCommunication(port, wantsBallPredictions, wantsQuickChat, wantsGameMessages);
+}
+
+bool Interface::IsReadyForCommunication() {
+    return _isReadyForCommunication();
 }
 } // namespace rlbot


### PR DESCRIPTION
The changes to botmanager.cc were adequate to fix CPP bots. Tested via https://github.com/kipje13/CPPExampleBot, where I made the changes directly in the git submodule.

Cherry picked the changes to here, builds successfully in CLion.

The flatbuffer changes are not related to the fix, just nice to have them up to date.