### PR TITLE
Fix Windows build issues with MinGW

### DIFF
--- a/inc/rlbot/platform.h
+++ b/inc/rlbot/platform.h
@@ -23,6 +23,11 @@ struct ModuleHandle {
 };
 
 const char fileSeperator = '\\';
+template <typename T>
+T GetFunctionAddress(ModuleHandle handle, const char *procname) {
+  return (T) GetProcAddress(handle.platform_specific, procname);
+}
+
 #endif
 
 #ifdef OS_UNIX
@@ -31,10 +36,10 @@ struct ModuleHandle {
 };
 
 const char fileSeperator = '/';
+void* GetFunctionAddress(ModuleHandle handle, const char *procname);
 #endif
 
 ModuleHandle LoadDll(const char *filename);
-void *GetFunctionAddress(ModuleHandle handle, const char *procname);
 void FreeDll(ModuleHandle handle);
 
 void SetWorkingDirectory(std::string directory);

--- a/inc/rlbot/server.h
+++ b/inc/rlbot/server.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <string>
 
 namespace rlbot {
 enum Command { Add, Remove };

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -36,34 +36,34 @@ void Interface::LoadInterface(std::string dll) {
   platform::ModuleHandle handle = platform::LoadDll(dll.c_str());
 
   _isInitialized =
-      (BoolFunc)platform::GetFunctionAddress(handle, "IsInitialized");
-  _free = (VoidFunc)platform::GetFunctionAddress(handle, "Free");
+      platform::GetFunctionAddress<BoolFunc>(handle, "IsInitialized");
+  _free = platform::GetFunctionAddress<VoidFunc>(handle, "Free");
 
   _updateLiveDataPacketFlatbuffer =
-      (ByteBufferFunc)platform::GetFunctionAddress(
+      platform::GetFunctionAddress<ByteBufferFunc>(
           handle, "UpdateLiveDataPacketFlatbuffer");
-  _updateFieldInfoFlatbuffer = (ByteBufferFunc)platform::GetFunctionAddress(
+  _updateFieldInfoFlatbuffer = platform::GetFunctionAddress<ByteBufferFunc>(
       handle, "UpdateFieldInfoFlatbuffer");
   _getBallPrediction =
-      (ByteBufferFunc)platform::GetFunctionAddress(handle, "GetBallPrediction");
+      platform::GetFunctionAddress<ByteBufferFunc>(handle, "GetBallPrediction");
   _getMatchSettings =
-      (ByteBufferFunc)platform::GetFunctionAddress(handle, "GetMatchSettings");
+      platform::GetFunctionAddress<ByteBufferFunc>(handle, "GetMatchSettings");
   _receiveChat =
-      (ReceiveQuickChatFunc)platform::GetFunctionAddress(handle, "ReceiveChat");
+      platform::GetFunctionAddress<ReceiveQuickChatFunc>(handle, "ReceiveChat");
 
-  _updatePlayerInputFlatbuffer = (SendPacketFunc)platform::GetFunctionAddress(
+  _updatePlayerInputFlatbuffer = platform::GetFunctionAddress<SendPacketFunc>(
       handle, "UpdatePlayerInputFlatbuffer");
   _renderGroup =
-      (SendPacketFunc)platform::GetFunctionAddress(handle, "RenderGroup");
+      platform::GetFunctionAddress<SendPacketFunc>(handle, "RenderGroup");
   _sendQuickChat =
-      (SendPacketFunc)platform::GetFunctionAddress(handle, "SendQuickChat");
+      platform::GetFunctionAddress<SendPacketFunc>(handle, "SendQuickChat");
   _setGameState =
-      (SendPacketFunc)platform::GetFunctionAddress(handle, "SetGameState");
-  _startMatchFlatbuffer = (SendPacketFunc)platform::GetFunctionAddress(
+      platform::GetFunctionAddress<SendPacketFunc>(handle, "SetGameState");
+  _startMatchFlatbuffer = platform::GetFunctionAddress<SendPacketFunc>(
       handle, "StartMatchFlatbuffer");
-  _startTcpCommunication = (CommsFunc)platform::GetFunctionAddress(
+  _startTcpCommunication = platform::GetFunctionAddress<CommsFunc>(
           handle, "StartTcpCommunication");
-  _isReadyForCommunication = (BoolFunc)platform::GetFunctionAddress(
+  _isReadyForCommunication = platform::GetFunctionAddress<BoolFunc>(
           handle, "IsReadyForCommunication");
 
   isLoaded = true;

--- a/src/platform_windows.cc
+++ b/src/platform_windows.cc
@@ -16,10 +16,6 @@ ModuleHandle LoadDll(const char *filename) {
   return handle;
 }
 
-void *GetFunctionAddress(ModuleHandle handle, const char *procname) {
-  return GetProcAddress(handle.platform_specific, procname);
-}
-
 void FreeDll(ModuleHandle handle) { FreeLibrary(handle.platform_specific); }
 
 void SetWorkingDirectory(std::string directory) { _chdir(directory.c_str()); }


### PR DESCRIPTION
When I first tried to build this repo with MinGW, I got build errors like the following for all of the functions in `platform_windows.cc`:

`RLBotCPP\src\platform_windows.cc:20:24: error: invalid conversion from 'FARPROC' {aka 'long long int (*)()'} to 'void*' [-fpermissive]`

Explicitly casting the type of each function instead of using `void*` resolved the issue for me. Tested on Windows 10 with MinGW installed via MSYS2 (GCC 10.3.0 x86_w64-mingw32).